### PR TITLE
Fix tar-fs path traversal vulnerability (CVE-2024-12905)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ws": "^7.5.10",
     "nth-check": "^2.0.1",
     "body-parser": "^1.20.3",
-    "path-to-regexp": "^0.1.12"
+    "path-to-regexp": "^0.1.12",
+    "tar-fs": "^2.1.2"
   },
   "resolutions": {
     "canvas": "2.9.3",
@@ -39,7 +40,8 @@
     "ws": "^7.5.10",
     "nth-check": "^2.0.1",
     "body-parser": "^1.20.3",
-    "path-to-regexp": "^0.1.12"
+    "path-to-regexp": "^0.1.12",
+    "tar-fs": "^2.1.2"
   },
   "dependencies": {
     "bunyan": "^1.8.12",


### PR DESCRIPTION
## Summary
- Adds an override for tar-fs to use version 2.1.2 or higher throughout the dependency tree
- Fixes CVE-2024-12905 vulnerability which allows path traversal attacks when extracting crafted tar files
- Closes issue #14

## Test plan
- Verify that tar-fs is using version 2.1.2+ when running yarn list --pattern tar-fs
- Verify that Dependabot alerts #29 and #30 are resolved after merging

🤖 Generated with [Claude Code](https://claude.ai/code)