### PR TITLE
Fix got package UNIX socket redirect vulnerability (CVE-2022-33987)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ws": "^7.5.10",
     "nth-check": "^2.0.1",
     "body-parser": "^1.20.3",
-    "path-to-regexp": "^0.1.12"
+    "path-to-regexp": "^0.1.12",
+    "got": "^11.8.5"
   },
   "resolutions": {
     "canvas": "2.9.3",
@@ -39,7 +40,8 @@
     "ws": "^7.5.10",
     "nth-check": "^2.0.1",
     "body-parser": "^1.20.3",
-    "path-to-regexp": "^0.1.12"
+    "path-to-regexp": "^0.1.12",
+    "got": "^11.8.5"
   },
   "dependencies": {
     "bunyan": "^1.8.12",


### PR DESCRIPTION
## Summary
- Adds an override for got to use version 11.8.5 or higher throughout the dependency tree
- Fixes CVE-2022-33987 vulnerability which allows redirection to UNIX sockets
- Closes issue #15

## Test plan
- Verify that got is using version 11.8.5+ when running yarn list --pattern got
- Verify that Dependabot alert #3 is resolved after merging

🤖 Generated with [Claude Code](https://claude.ai/code)